### PR TITLE
Create/Modify issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -45,7 +45,7 @@ about: For reporting issues with the VA API Platform
 
 ## Steps to reproduce
 
-<!-- Please include any details about your environment, language, browser, operating system, etc that will help us to reproduce. -->
+<!-- Please include any details about your development environment, language, browser, operating system, etc that will help us to reproduce. -->
 
 1. 
 2. 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -11,9 +11,14 @@ about: For reporting issues with the VA API Platform
 <!-- Please include your email address. -->
 
 
-## APIs affected
+## APIs affected (if applicable)
 
-<!-- Please list affected APIs (if applicable). -->
+<!-- Please list affected APIs. -->
+
+
+## API version (if applicable)
+
+<!-- Please note the API version that is affected. -->
 
 
 ## What I expected to happen

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -3,10 +3,7 @@ name: 🔴 Bug Report
 about: For reporting issues with the VA API Platform
 ---
 
-Important note: As this is a public forum, please do not include your VA API OAuth Client ID, VA API OAuth Client Secret, VA API key, or any Personally Identifiable Information (PII) or Protected Health Information (PHI) in your report.
-
-### Troubleshooting note
-* For test apps, please make sure you are using your registered URL, not the URL provided in the example.
+⚠️ Please read before submitting: As this is a public forum, please do not include your VA API OAuth Client ID, VA API OAuth Client Secret, VA API key, or any Personally Identifiable Information (PII) or Protected Health Information (PHI) in your report. For test apps, please make sure you are using your registered redirect URL, not the URL provided in the example.
 
 
 ## Email address
@@ -21,17 +18,24 @@ Important note: As this is a public forum, please do not include your VA API OAu
 
 ## What I expected to happen
 
-<!-- What did you expect to happen? --> 
+<!-- Please provide a step by step summary of what the expected behavior was. -->
+1. 
+2. 
+3. 
 
 
 ## What actually happened
 
-<!-- Describe in detail what went wrong. Screenshots, gifs, and videos are encouraged. --> 
+<!-- Describe in detail what went wrong. Screenshots, gifs, and videos are encouraged. -->
 
 
 ## Severity of the issue
 
 <!-- Please indicate how severe this issue is for your use case. -->
+
+[ ] High severity: Blocking work
+[ ] Medium severity: Not blocking work, but needs attention
+[ ] Low severity: Needs attention in a timely manner
 
 [ ] I am unable to use the API
 [ ] I was able to use the API, but am not getting the results I expected

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -33,14 +33,14 @@ about: For reporting issues with the VA API Platform
 
 <!-- Please indicate how severe this issue is for your use case. -->
 
-[ ] High severity: Blocking work
-[ ] Medium severity: Not blocking work, but needs attention
-[ ] Low severity: Needs attention in a timely manner
+- [ ] High severity: Blocking work
+- [ ] Medium severity: Not blocking work, but needs attention
+- [ ] Low severity: Needs attention in a timely manner
 
-[ ] I am unable to use the API
-[ ] I was able to use the API, but am not getting the results I expected
-[ ] I was able to workaround the issue
-    <!-- Please explain the workaround. -->
+- [ ] I am unable to use the API
+- [ ] I was able to use the API, but am not getting the results I expected
+- [ ] I was able to workaround the issue
+      <!-- Please explain the workaround. -->
 
 
 ## Steps to reproduce

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,22 +1,48 @@
 ---
-name: Bug Report
-about: Reporting issues with the VA API Platform
-
+name: 🔴 Bug Report
+about: For reporting issues with the VA API Platform
 ---
 
-## APIs Affected
+Important note: As this is a public forum, please do not include your VA API OAuth Client ID, VA API OAuth Client Secret, VA API key, or any Personally Identifiable Information (PII) or Protected Health Information (PHI) in your report.
 
-<!-- Please list affected APIs -->
+### Troubleshooting note
+* For test apps, please make sure you are using your registered URL, not the URL provided in the example.
 
-## Brief Summary 
 
-<!-- One or two sentence summary of the issue. --> 
+## Email address
 
-## Severity of the Issue
+<!-- Please include your email address. -->
+
+
+## APIs affected
+
+<!-- Please list affected APIs (if applicable). -->
+
+
+## What I expected to happen
+
+<!-- What did you expect to happen? --> 
+
+
+## What actually happened
+
+<!-- Describe in detail what went wrong. Screenshots, gifs, and videos are encouraged. --> 
+
+
+## Severity of the issue
 
 <!-- Please indicate how severe this issue is for your use case. -->
-<!-- Does it prevent you from using the API? Were you able to workaround? -->
 
-## Steps to Reproduce
+[ ] I am unable to use the API
+[ ] I was able to use the API, but am not getting the results I expected
+[ ] I was able to workaround the issue
+    <!-- Please explain the workaround. -->
 
-<!-- Please include any details about your environment, language, browser, operating system, etc that will help us reproduce. -->
+
+## Steps to reproduce
+
+<!-- Please include any details about your environment, language, browser, operating system, etc that will help us to reproduce. -->
+
+1. 
+2. 
+3. 

--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -1,6 +1,6 @@
 ---
-name: 💡 Feature Request
-about: For requesting new features or enhancements on the VA API Platform
+name: 📖 Documentation Request
+about: For requesting new documentation or updates on the VA API Platform
 ---
 
 Important note: As this is a public forum, please do not include your VA API OAuth Client ID, VA API OAuth Client Secret, VA API key, or any Personally Identifiable Information (PII) or Protected Health Information (PHI) in your request.
@@ -18,12 +18,12 @@ Important note: As this is a public forum, please do not include your VA API OAu
 
 ## Explanation
 
-<!-- Summary of the request. Please provide a code sample if you have one. -->
+<!-- Summary of the request. -->
 
 
-## Value provided by feature
+## Link to existing documentation
 
-<!-- Explanation of why this feature would help your use case or be generally useful. --> 
+<!-- Please provide the link to where the current documentation lives (if applicable). --> 
 
 
 ## Acceptance criteria

--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -11,9 +11,14 @@ about: For requesting new documentation or updates on the VA API Platform
 <!-- Please include your email address. -->
 
 
-## APIs affected
+## APIs affected (if applicable)
 
-<!-- Please list affected APIs (if applicable). -->
+<!-- Please list affected APIs. -->
+
+
+## API version (if applicable)
+
+<!-- Please note the API version that is affected. -->
 
 
 ## Explanation

--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -3,7 +3,7 @@ name: 📖 Documentation Request
 about: For requesting new documentation or updates on the VA API Platform
 ---
 
-Important note: As this is a public forum, please do not include your VA API OAuth Client ID, VA API OAuth Client Secret, VA API key, or any Personally Identifiable Information (PII) or Protected Health Information (PHI) in your request.
+⚠️ Please read before submitting: As this is a public forum, please do not include your VA API OAuth Client ID, VA API OAuth Client Secret, VA API key, or any Personally Identifiable Information (PII) or Protected Health Information (PHI) in your request.
 
 
 ## Email address
@@ -23,7 +23,7 @@ Important note: As this is a public forum, please do not include your VA API OAu
 
 ## Link to existing documentation
 
-<!-- Please provide the link to where the current documentation lives (if applicable). --> 
+<!-- Please provide the link to where the current documentation lives (if applicable). -->
 
 
 ## Acceptance criteria

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -3,7 +3,7 @@ name: 💡 Feature Request
 about: For requesting new features or enhancements on the VA API Platform
 ---
 
-Important note: As this is a public forum, please do not include your VA API OAuth Client ID, VA API OAuth Client Secret, VA API key, or any Personally Identifiable Information (PII) or Protected Health Information (PHI) in your request.
+⚠️ Please read before submitting: As this is a public forum, please do not include your VA API OAuth Client ID, VA API OAuth Client Secret, VA API key, or any Personally Identifiable Information (PII) or Protected Health Information (PHI) in your request.
 
 
 ## Email address
@@ -18,12 +18,12 @@ Important note: As this is a public forum, please do not include your VA API OAu
 
 ## Explanation
 
-<!-- Summary of the request. Please provide a code sample if you have one. -->
+<!-- Summary of the request -->
 
 
 ## Value provided by feature
 
-<!-- Explanation of why this feature would help your use case or be generally useful. --> 
+<!-- Explanation of why this feature would help your use case or be generally useful. -->
 
 
 ## Acceptance criteria

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -11,9 +11,9 @@ about: For requesting new features or enhancements on the VA API Platform
 <!-- Please include your email address. -->
 
 
-## APIs affected
+## APIs affected (if applicable)
 
-<!-- Please list affected APIs (if applicable). -->
+<!-- Please list affected APIs. -->
 
 
 ## Explanation

--- a/.github/ISSUE_TEMPLATE/support-request.md
+++ b/.github/ISSUE_TEMPLATE/support-request.md
@@ -1,0 +1,34 @@
+---
+name: 🆘 Support Request
+about: For requesting general support with the VA API Platform
+---
+
+Important note: As this is a public forum, please do not include your VA API OAuth Client ID, VA API OAuth Client Secret, VA API key, or any Personally Identifiable Information (PII) or Protected Health Information (PHI) in your request.
+
+### Troubleshooting note
+* For test apps, please make sure you are using your registered URL, not the URL provided in the example.
+
+
+## Email address
+
+<!-- Please include your email address. -->
+
+
+## APIs affected
+
+<!-- Please list affected APIs (if applicable). -->
+
+
+## How can we help?
+
+<!-- Describe what we can help you with. -->
+
+
+## What have you tried?
+
+<!-- Describe in detail what you have already tried. --> 
+
+
+## Additional context
+
+<!-- Add any other context or screenshots here. -->

--- a/.github/ISSUE_TEMPLATE/support-request.md
+++ b/.github/ISSUE_TEMPLATE/support-request.md
@@ -3,10 +3,7 @@ name: 🆘 Support Request
 about: For requesting general support with the VA API Platform
 ---
 
-Important note: As this is a public forum, please do not include your VA API OAuth Client ID, VA API OAuth Client Secret, VA API key, or any Personally Identifiable Information (PII) or Protected Health Information (PHI) in your request.
-
-### Troubleshooting note
-* For test apps, please make sure you are using your registered URL, not the URL provided in the example.
+⚠️ Please read before submitting: As this is a public forum, please do not include your VA API OAuth Client ID, VA API OAuth Client Secret, VA API key, or any Personally Identifiable Information (PII) or Protected Health Information (PHI) in your report. For test apps, please make sure you are using your registered redirect URL, not the URL provided in the example.
 
 
 ## Email address
@@ -26,7 +23,7 @@ Important note: As this is a public forum, please do not include your VA API OAu
 
 ## What have you tried?
 
-<!-- Describe in detail what you have already tried. --> 
+<!-- Describe in detail what you have already tried. -->
 
 
 ## Additional context

--- a/.github/ISSUE_TEMPLATE/support-request.md
+++ b/.github/ISSUE_TEMPLATE/support-request.md
@@ -11,9 +11,9 @@ about: For requesting general support with the VA API Platform
 <!-- Please include your email address. -->
 
 
-## APIs affected
+## APIs affected (if applicable)
 
-<!-- Please list affected APIs (if applicable). -->
+<!-- Please list affected APIs. -->
 
 
 ## How can we help?


### PR DESCRIPTION
The `Send us your feedback` link in the developer portal homepage banner and the `Support` main nav item both point to [the vets-api-clients new issue page](https://github.com/department-of-veterans-affairs/vets-api-clients/issues/new/choose). Therefore, we need issue templates that can accommodate a wide range of requests.

The existing `Feature Request` and `Bug Report` templates were modified to gather more of the required info up front, and allow us to more easily route requests to the right team. Also, new templates were added for `Documentation Update` and `Support Request`.