### PR TITLE
Update README.md to include Statuspage link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,6 @@ Note that the Health (FHIR / Argonaut) APIs for access to Veteran health records
 
 ## Further Assistance
 If you have any questions or need further assistance, please email our team at api@va.gov. You will receive a human reply within 24 hours.  Additionally, you may open a comment or support request [inside this repo](https://github.com/department-of-veterans-affairs/vets-api-clients/issues/new/choose).
+
+## Incident and Outage Awareness (Statuspage)
+Please visit and subscribe to alerts from the [VA Lighthouse Statuspage](https://valighthouse.statuspage.io/) for up-to-the minute reports on API and gateway functionality.  Currently monitoring the dev environment only, with production coming soon.

--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ Note that the Health (FHIR / Argonaut) APIs for access to Veteran health records
 If you have any questions or need further assistance, please email our team at api@va.gov. You will receive a human reply within 24 hours.  Additionally, you may open a comment or support request [inside this repo](https://github.com/department-of-veterans-affairs/vets-api-clients/issues/new/choose).
 
 ## Incident and Outage Awareness (Statuspage)
-Please visit and subscribe to alerts from the [VA Lighthouse Statuspage](https://valighthouse.statuspage.io/) for up-to-the minute reports on API and gateway functionality.  Currently monitoring the dev environment only, with production coming soon.
+Please visit and subscribe to alerts from the [VA Lighthouse Statuspage](https://valighthouse.statuspage.io/) for up-to-the minute reports on API and gateway functionality. Currently monitoring the dev environment only, with production coming soon.


### PR DESCRIPTION
This adds a paragraph to the bottom of `vets-api-clients` README.md with a link to Lighthouse Statuspage.