### PR TITLE
fix oauth login for expires_at key removal

### DIFF
--- a/samples/oauth_rails/VetsApiClaims/app/models/session.rb
+++ b/samples/oauth_rails/VetsApiClaims/app/models/session.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 
 class Session < ApplicationRecord
+
+  attr_accessor :expires_in
+
   def self.new_from_oauth(response)
+    response['expires_at'] = response['expires_in'].seconds.from_now
     attributes_array = response.map do |key, value|
-      clean_value =
-        if key == 'expires_at'
-          Time.zone.at(value)
-        else
-          value
-        end
-      [key, clean_value]
+      [key, value]
     end
     Session.new(Hash[attributes_array])
   end

--- a/samples/oauth_rails/VetsApiClaims/app/models/session.rb
+++ b/samples/oauth_rails/VetsApiClaims/app/models/session.rb
@@ -6,10 +6,7 @@ class Session < ApplicationRecord
 
   def self.new_from_oauth(response)
     response['expires_at'] = response['expires_in'].seconds.from_now
-    attributes_array = response.map do |key, value|
-      [key, value]
-    end
-    Session.new(Hash[attributes_array])
+    Session.new(response)
   end
 
   def expired?


### PR DESCRIPTION
The oauth response is now sending an expires_in key vs expires_at. This PR fixes the sample app to use the new key for the session expire time.