### PR TITLE
Displaying error_description

### DIFF
--- a/samples/oauth_node/index.js
+++ b/samples/oauth_node/index.js
@@ -74,6 +74,14 @@ const verifyVeteranStatus = async (req, res, next) => {
   }
 };
 
+const wrapAuth = async (req, res, next) => {
+  //Passport or OIDC don't seem to set 'err' if our Auth Server sets them in the URL as params so we need to do this to catch that instead of relying on callback
+  if (req.query.error) {
+    return next(req.query.error_description);
+  }
+  passport.authenticate("oidc", { successRedirect: "/", failureRedirect: "/"});
+};
+
 const startApp = (client) => {
   const app = express();
   const port = 8080;
@@ -86,10 +94,7 @@ const startApp = (client) => {
   app.get('/status', verifyVeteranStatus);
 
   app.get('/auth', passport.authenticate('oidc'));
-  app.get(
-    '/auth/cb',
-    passport.authenticate('oidc', { successRedirect: '/', failureRedirect: '/'})
-  );
+  app.get('/auth/cb', wrapAuth);
 
   app.listen(port, () => console.log(`Example app listening on port ${port}!`));
 }


### PR DESCRIPTION
This is addressing issue around the oauth node sample app not handling the Auth server sending back an error when authenticating as a veteran.

https://vasdvp.atlassian.net/browse/PIV-242

I would like to note that when I was first testing this I saw that the error being passed back is from not registering my test Okta account with the callback url required by this sample app: http://localhost:8080/auth/cb. This will display the error more nicely at least but we should probably consider how to either provide test app credentials or warn people that they need this as a registered URI.