### PR TITLE
Api 1981 sample clients aud support

### DIFF
--- a/samples/oauth_node/.env.sample
+++ b/samples/oauth_node/.env.sample
@@ -1,3 +1,4 @@
 CLIENT_ID=
 CLIENT_SECRET=
 ENVIRONMENT=sandbox
+AUDIENCE=api://default

--- a/samples/oauth_node/README.md
+++ b/samples/oauth_node/README.md
@@ -25,11 +25,11 @@ docker run --rm -d -p 8080:8080 \
   -e CLIENT_ID=FAKE_CLIENT_ID \
   -e CLIENT_SECRET=FAKE_CLIENT_SECRET \
   -e ENVIRONMENT=sandbox \
+  -e AUDIENCE=api://default
   oauth-node-sample-client
 ```
 
 Replace `FAKE_CLIENT_ID` and `FAKE_CLIENT_SECRET` with your ID and secret.
-
 ## Running without Docker
 
 ### Requirements

--- a/samples/oauth_node/README.md
+++ b/samples/oauth_node/README.md
@@ -25,7 +25,7 @@ docker run --rm -d -p 8080:8080 \
   -e CLIENT_ID=FAKE_CLIENT_ID \
   -e CLIENT_SECRET=FAKE_CLIENT_SECRET \
   -e ENVIRONMENT=sandbox \
-  -e AUDIENCE=api://default
+  -e AUDIENCE=api://default \
   oauth-node-sample-client
 ```
 

--- a/samples/oauth_node/index.js
+++ b/samples/oauth_node/index.js
@@ -10,6 +10,7 @@ const env = process.env.ENVIRONMENT;
 const ROOT_URL = `https://${env}-api.va.gov/oauth2/.well-known/openid-configuration`;
 const client_id = process.env.CLIENT_ID;
 const client_secret = process.env.CLIENT_SECRET;
+const audience = process.env.AUDIENCE;
 var bodyParser = require('body-parser');
 
 const createClient = async () => {
@@ -39,6 +40,7 @@ const configurePassport = (client) => {
       client,
       params: {
         scope: 'openid profile veteran_status.read claim.read',
+        aud: audience,
       },
     }, (tokenset, userinfo, done) => {
       done(null, { userinfo, tokenset });

--- a/samples/oauth_pkce_cli/README.md
+++ b/samples/oauth_pkce_cli/README.md
@@ -13,6 +13,7 @@ It follows these steps:
     d. a randomly generated state value
     e. the `code challenge`
     f. a response type set to `code` to indicate that we're using the authorization code flow
+    g. the `aud` parameter to indicate the audience of the API calls
 4. Launches a browser with the authorization URL, at which point you will authenticate
 5. Receives the redirect from the authorization url, which includes a `code`
 6. Calls the `token` endpoint with:
@@ -36,7 +37,8 @@ Usage: pkce-cli [options]
 
 Options:
   -c, --client_id <client id>                    OIDC Client ID (default: "")
-  -a, --auth_server <auth server url>            ex: https://sandbox-api.va.gov/oauth2 (default: "")
+  -a, --auth_server <auth server url>            ex: https://sandbox-api.va.gov (default: "")
+  -d, --audience <resource server url>           ex: api://default
   -s, --scopes <space separated list of scopes>  Space separated list of scopes (default: "")
   -r, --redirect_uri <redirect uri>              redirect uri (default: "http://localhost:8080/redirect")
   -h, --help                                     output usage information
@@ -49,7 +51,8 @@ Options:
   --client_id 00000000000000000000 \
   --auth_server https://sandbox-api.va.gov/oauth2 \
   --scopes "openid profile email" \
-  --redirect_uri http://localhost:8080/redirect
+  --audience api://default 
+  --redirect_uri http://localhost:8080/redirect 
 ```
 
 You'll get output like this, along with prompts to continue, as well as a browser session being initiated to authenticate a user:

--- a/samples/oauth_pkce_cli/pkce-cli
+++ b/samples/oauth_pkce_cli/pkce-cli
@@ -10,7 +10,8 @@ var opn = require('opn');
 
 program
   .option('-c, --client_id <client id>', 'OIDC Client ID', '')
-  .option('-a, --auth_server <auth server url>', 'ex: https://sandbox-api.va.gov/oauth2', '')
+  .option('-a, --auth_server <auth server url>', 'ex: https://sandbox-api.va.gov', '')
+  .option('-d, --audience <resource server url>', 'ex: api://default', '')
   .option('-s, --scopes <space separated list of scopes>', 'Space separated list of scopes', 'openid profile email')
   .option('-r, --redirect_uri <redirect uri>', 'redirect uri', 'http://localhost:8080/redirect')
   .parse(process.argv);
@@ -143,6 +144,7 @@ function buildAuthorizeUrl(codeVerifier, codeChallenge) {
 	var authorizeUrl = program.auth_server + '/authorization?' +
     'client_id=' + program.client_id + '&' +
     'response_type=code&' +
+    'aud=' + program.audience + '&' +
     'scope=' + program.scopes + '&' +
     'redirect_uri=' + program.redirect_uri + '&' +
     'state=' + uuid() + '&' +

--- a/samples/oauth_rails/VetsApiClaims/app/controllers/application_controller.rb
+++ b/samples/oauth_rails/VetsApiClaims/app/controllers/application_controller.rb
@@ -26,6 +26,7 @@ class ApplicationController < ActionController::Base
       # response_mode: 'fragment', # defaults to fragment, but this is where it would be changed
       response_type: 'code',
       scope: scope,
+      aud: Figaro.env.audience,
       state: session[:login_time]
     }
     @oauth_url = "#{Figaro.env.vets_api_url}/oauth2/authorization?#{oauth_params.to_query}"

--- a/samples/oauth_rails/VetsApiClaims/app/controllers/auth_controller.rb
+++ b/samples/oauth_rails/VetsApiClaims/app/controllers/auth_controller.rb
@@ -14,6 +14,7 @@ class AuthController < ApplicationController
       # response_mode: 'fragment', # defaults to fragment, but this is where it would be changed
       response_type: 'code',
       scope: scope,
+      aud: Figaro.env.audience,
       state: session[:login_time]
     }
     @oauth_url = "#{Figaro.env.vets_api_url}/oauth2/authorization?#{oauth_params.to_query}"

--- a/samples/oauth_rails/VetsApiClaims/config/application.yml.EXAMPLE
+++ b/samples/oauth_rails/VetsApiClaims/config/application.yml.EXAMPLE
@@ -2,3 +2,4 @@
 va_developer_client_id: 
 va_developer_client_secret: 
 vets_api_url: 'https://sandbox-api.va.gov'
+audience: 'api://default'

--- a/samples/oauth_rails/vethealth/README.md
+++ b/samples/oauth_rails/vethealth/README.md
@@ -6,7 +6,7 @@ This is a sample app that will connect with the oauth provider to access Health 
 
 Set up your API credentials at the [Developer Portal](https://developer.va.gov/apply).  The callback for this app to work needs to be `http://localhost:3000/callback`.
 
-The sample app uses the default SQLite database setup and `rails db:migrate` will generate the sqlite3 file with the table needed to run the app.  **The app expects the file `config/application.yml` to contain a key for `va_developer_client_id` and `va_developer_client_secret`**.  `config/application.yml.EXAMPLE` is an example config (to make sure the credentials file remains untracked in git).  To use it, make a copy without the `.EXAMPLE` extension and fill in your credentials.
+The sample app uses the default SQLite database setup and `rails db:migrate` will generate the sqlite3 file with the table needed to run the app.  **The app expects the file `config/application.yml` to contain a key for `audience`,`va_developer_client_id`, `va_developer_client_secret`**.  `config/application.yml.EXAMPLE` is an example config (to make sure the credentials file remains untracked in git).  To use it, make a copy without the `.EXAMPLE` extension and fill in your credentials.
 
 ## Exploring the Health APIs
 

--- a/samples/oauth_rails/vethealth/app/controllers/session_controller.rb
+++ b/samples/oauth_rails/vethealth/app/controllers/session_controller.rb
@@ -15,6 +15,7 @@ class SessionController < ApplicationController
       # response_mode: 'fragment',
       response_type: 'code',
       scope: scope,
+      aud: ENV['audience'],
       state: session[:login_time]
     }
     @oauth_url = "https://sandbox-api.va.gov/oauth2/authorization?#{@oauth_params.to_query}"
@@ -24,6 +25,7 @@ class SessionController < ApplicationController
       {param: :client_id, description: "The client_id issued by the VA API Platform team", required: true},
       {param: :nonce, description: "Used with id_token to verify token integrity. Ensure the nonce in your id_token is the same as this value."},
       {param: :redirect_uri, description: "The URL you supplied when signing up for access.", required: true},
+      {param: :aud, description: "The URL the resource server your application will make requests to.", required: true},
       # TODO uncomment this description, known issue is causing a 500 if this param is used https://github.com/department-of-veterans-affairs/vets-contrib/issues/1842
       # {param: :response_mode, description: "Either fragment or query, recommended not to use unless you have a specific reason. Defaults to fragment so it can be omitted."},
       {param: :response_type, description: "Set to <code>code</code> to use the Authorization Code Flow.", required: true},

--- a/samples/oauth_rails/vethealth/app/models/authentication.rb
+++ b/samples/oauth_rails/vethealth/app/models/authentication.rb
@@ -1,16 +1,17 @@
 class Authentication < ApplicationRecord
   serialize :id_token
   belongs_to :oauth_callback, optional: true
-
+  
+  attr_accessor :expires_in
   attr_reader :authentication_errors
 
   def self.generate_nonce(base)
-    Digest::SHA256.hexdigest(base + ENV['va_developer_client_secret'])
+    Digest::SHA256.hexdigest(base.to_s + ENV['va_developer_client_secret'])
   end
 
   def self.attributes_from_oauth(response)
+    response['expires_at'] = response['expires_in'].seconds.from_now
     attributes = response.to_h
-    attributes['expires_at'] = Time.zone.at(response['expires_at'])
     attributes
   end
 

--- a/samples/oauth_rails/vethealth/app/models/health_api_response.rb
+++ b/samples/oauth_rails/vethealth/app/models/health_api_response.rb
@@ -6,10 +6,10 @@ class HealthApiResponse
     case action
     when :search
       @page, @count = page, count
-      @target = "https://sandbox-api.va.gov/services/argonaut/v0/#{api_name}?#{search_param_name}=#{id}&page=#{page}&_count=#{count}"
+      @target = "https://sandbox-api.va.gov/services/fhir/v0/argonaut/data-query/#{api_name}?#{search_param_name}=#{id}&page=#{page}&_count=#{count}"
     when :read
       @page, @count = nil, nil
-      @target = "https://sandbox-api.va.gov/services/argonaut/v0/#{api_name}/#{id}"
+      @target = "https://sandbox-api.va.gov/services/fhir/v0/argonaut/data-query/#{api_name}/#{id}"
     else
       raise "action must be one of the symbols :search or :read"
     end

--- a/samples/oauth_rails/vethealth/config/application.yml.EXAMPLE
+++ b/samples/oauth_rails/vethealth/config/application.yml.EXAMPLE
@@ -1,3 +1,4 @@
 # TODO put your client id and client secret here and remove the `.EXAMPLE` extension
 va_developer_client_id:
 va_developer_client_secret:
+audience: 'api://default'

--- a/samples/oauth_rails/vethealth/config/initializers/figaro.rb
+++ b/samples/oauth_rails/vethealth/config/initializers/figaro.rb
@@ -1,4 +1,5 @@
 Figaro.require_keys(
   'va_developer_client_id',
-  'va_developer_client_secret'
+  'va_developer_client_secret',
+  'audience'
 )

--- a/samples/oauth_rails/vethealth/test/models/health_api_response_test.rb
+++ b/samples/oauth_rails/vethealth/test/models/health_api_response_test.rb
@@ -47,7 +47,7 @@ class HealthApiResponseTest < ActiveSupport::TestCase
     body = {
       id: 1234,
       attributes: {
-        link: "https://sandbox-api.va.gov/services/argonaut/v0/#{api_name}/1234"
+        link: "https://sandbox-api.va.gov/services/fhir/v0/argonaut/data-query/#{api_name}/1234"
       }
     }
     stub_request(:get, /dev-api\.va\.gov/).
@@ -62,23 +62,23 @@ class HealthApiResponseTest < ActiveSupport::TestCase
       link: [
         {
           relation: "first",
-          url: "https://sandbox-api.va.gov/services/argonaut/v0/DiagnosticReport?patient=59&page=1&_count=10"
+          url: "https://sandbox-api.va.gov/services/fhir/v0/argonaut/data-query/DiagnosticReport?patient=59&page=1&_count=10"
         },
         {
           relation: "prev",
-          url: "https://sandbox-api.va.gov/services/argonaut/v0/DiagnosticReport?patient=59&page=1&_count=10"
+          url: "https://sandbox-api.va.gov/services/fhir/v0/argonaut/data-query/DiagnosticReport?patient=59&page=1&_count=10"
         },
         {
           relation: "self",
-          url: "https://sandbox-api.va.gov/services/argonaut/v0/DiagnosticReport?patient=59&page=2&_count=10"
+          url: "https://sandbox-api.va.gov/services/fhir/v0/argonaut/data-query/DiagnosticReport?patient=59&page=2&_count=10"
         },
         {
           relation: "next",
-          url: "https://sandbox-api.va.gov/services/argonaut/v0/DiagnosticReport?patient=59&page=3&_count=10"
+          url: "https://sandbox-api.va.gov/services/fhir/v0/argonaut/data-query/DiagnosticReport?patient=59&page=3&_count=10"
         },
         {
           relation: "last",
-          url: "https://sandbox-api.va.gov/services/argonaut/v0/DiagnosticReport?patient=59&page=4&_count=10"
+          url: "https://sandbox-api.va.gov/services/fhir/v0/argonaut/data-query/DiagnosticReport?patient=59&page=4&_count=10"
         }
       ]
     }

--- a/samples/oauth_rails/vetverification/README.md
+++ b/samples/oauth_rails/vetverification/README.md
@@ -6,7 +6,7 @@ This is a sample app that will connect with the oauth provider to access Veteran
 
 Set up your API credentials at the [Developer Portal](https://developer.va.gov/apply).  The callback for this app to work needs to be `http://localhost:3000/callback`.
 
-The sample app uses the default SQLite database setup and `rails db:migrate` will generate the sqlite3 file with the table needed to run the app.  **The app expects the file `config/application.yml` to contain a key for `va_developer_client_id` and `va_developer_client_secret`**.  `config/application.yml.EXAMPLE` is an example config (to make sure the credentials file remains untracked in git).  To use it, make a copy without the `.EXAMPLE` extension and fill in your credentials.
+The sample app uses the default SQLite database setup and `rails db:migrate` will generate the sqlite3 file with the table needed to run the app.  **The app expects the file `config/application.yml` to contain a key for `audience`,`va_developer_client_id`, `va_developer_client_secret`**.  `config/application.yml.EXAMPLE` is an example config (to make sure the credentials file remains untracked in git).  To use it, make a copy without the `.EXAMPLE` extension and fill in your credentials.
 
 ## Using the app
 

--- a/samples/oauth_rails/vetverification/app/controllers/auth_controller.rb
+++ b/samples/oauth_rails/vetverification/app/controllers/auth_controller.rb
@@ -12,6 +12,7 @@ class AuthController < ApplicationController
       # response_mode: 'fragment', # defaults to fragment, but this is where it would be changed
       response_type: 'code',
       scope: scope,
+      aud: ENV['audience'],
       state: session[:login_time]
     }
     @oauth_url = "https://sandbox-api.va.gov/oauth2/authorization?#{oauth_params.to_query}"

--- a/samples/oauth_rails/vetverification/app/models/session.rb
+++ b/samples/oauth_rails/vetverification/app/models/session.rb
@@ -1,19 +1,14 @@
 class Session < ApplicationRecord
+
   def self.new_from_oauth(response)
-    attributes_array = response.map do |key,value|
-      clean_value =
-        if key == 'expires_at'
-          Time.zone.at(value)
-        else
-          value
-        end
-      [key, clean_value]
-    end
-    Session.new(Hash[attributes_array])
+    response['expires_in'] = response['expires_in'].seconds.from_now
+    attributes = response.to_h
+    attributes
+    Session.new(Hash[attributes])
   end
 
   def expired?
-    @expired ||= self.expires_at < Time.zone.now
+    @expired ||= self.expires_in < Time.zone.now
   end
 
   def veteran_verification

--- a/samples/oauth_rails/vetverification/app/models/veteran_verification.rb
+++ b/samples/oauth_rails/vetverification/app/models/veteran_verification.rb
@@ -35,7 +35,6 @@ class VeteranVerification
 
     @disability_ratings = []
     return @disability_ratings if disability_ratings_response.code != 200
-    Rails.logger.warn disability_ratings_response['data']
     disability_ratings_response['data']["attributes"].each do |key, value|
       modified_rating = {}
       modified_rating[key] =
@@ -65,7 +64,6 @@ class VeteranVerification
       end
       @individual_disability_ratings << individual_rating
     end 
-    Rails.logger.warn @individual_disability_ratings
     @individual_disability_ratings
   end
 

--- a/samples/oauth_rails/vetverification/app/models/veteran_verification.rb
+++ b/samples/oauth_rails/vetverification/app/models/veteran_verification.rb
@@ -35,16 +35,16 @@ class VeteranVerification
 
     @disability_ratings = []
     return @disability_ratings if disability_ratings_response.code != 200
-    disability_ratings_response['data'].each do |rating|
+    Rails.logger.warn disability_ratings_response['data']
+    disability_ratings_response['data']["attributes"].each do |key, value|
       modified_rating = {}
-      rating['attributes'].each do |key,value|
-        modified_rating[key] =
-          if key == 'effective_date'
-            Time.zone.parse(value)
-          else
-            value
-          end
-      end
+      modified_rating[key] =
+        if key == 'effective_date'
+          Time.zone.parse(value)
+        else
+          value
+        end
+
       @disability_ratings << modified_rating
     end
     @disability_ratings

--- a/samples/oauth_rails/vetverification/app/models/veteran_verification.rb
+++ b/samples/oauth_rails/vetverification/app/models/veteran_verification.rb
@@ -50,6 +50,25 @@ class VeteranVerification
     @disability_ratings
   end
 
+  def individual_disability_ratings
+    return @individual_disability_ratings if @individual_disability_ratings
+
+    @individual_disability_ratings = []
+    return @individual_disability_ratings if disability_ratings_response.code != 200
+    disability_ratings_response['data']["attributes"]["individual_ratings"].each do |individual_rating|
+      individual_rating.each do |key, value|
+          if key == 'effective_date'
+            value = Time.zone.parse(value)
+          else
+            value
+          end
+      end
+      @individual_disability_ratings << individual_rating
+    end 
+    Rails.logger.warn @individual_disability_ratings
+    @individual_disability_ratings
+  end
+
   def disability_ratings_response
     @disability_ratings_response = get('disability_rating', allow: [402])
   end

--- a/samples/oauth_rails/vetverification/app/views/verification/show.html.erb
+++ b/samples/oauth_rails/vetverification/app/views/verification/show.html.erb
@@ -13,11 +13,11 @@
     </div>
     <% end %>
 
-    <% if @veteran_verification.disability_ratings.any? %>
+    <% if @veteran_verification.individual_disability_ratings.any? %>
     <div class="row">
         <h3 class="col-12">Disability</h3>
         <small class="col-12"><%= link_to 'Disability Ratings API Documentation', 'https://developer.va.gov/explore/verification/docs/disability_rating', target: '_blank', title: 'Disability Rating Documentation' %></small>
-        <%= render partial: "disability_rating", collection: @veteran_verification.disability_ratings %>
+        <%= render partial: "disability_rating", collection: @veteran_verification.individual_disability_ratings %>
     </div>
     <% end %>
 

--- a/samples/oauth_rails/vetverification/config/application.yml.EXAMPLE
+++ b/samples/oauth_rails/vetverification/config/application.yml.EXAMPLE
@@ -1,3 +1,4 @@
 # TODO put your client id and client secret here and remove the `.EXAMPLE` extension
 va_developer_client_id: 
 va_developer_client_secret: 
+audience: 'api://default'

--- a/samples/oauth_rails/vetverification/config/initializers/figaro.rb
+++ b/samples/oauth_rails/vetverification/config/initializers/figaro.rb
@@ -1,4 +1,5 @@
 Figaro.require_keys(
   'va_developer_client_id',
-  'va_developer_client_secret'
+  'va_developer_client_secret',
+  'audience'
 )

--- a/samples/oauth_rails/vetverification/db/migrate/20190411015604_create_sessions.rb
+++ b/samples/oauth_rails/vetverification/db/migrate/20190411015604_create_sessions.rb
@@ -3,7 +3,7 @@ class CreateSessions < ActiveRecord::Migration[5.2]
     create_table :sessions do |t|
       t.string :access_token
       t.string :token_type
-      t.datetime :expires_at
+      t.datetime :expires_in
       t.string :scope
       t.string :id_token
       t.string :state

--- a/samples/oauth_rails/vetverification/db/schema.rb
+++ b/samples/oauth_rails/vetverification/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema.define(version: 2019_04_11_015604) do
   create_table "sessions", force: :cascade do |t|
     t.string "access_token"
     t.string "token_type"
-    t.datetime "expires_at"
+    t.datetime "expires_in"
     t.string "scope"
     t.string "id_token"
     t.string "state"

--- a/samples/oauth_rails/vetverification/test/fixtures/sessions.yml
+++ b/samples/oauth_rails/vetverification/test/fixtures/sessions.yml
@@ -3,7 +3,7 @@
 one:
   access_token: MyString
   token_type: MyString
-  expires_at: 2019-04-10 21:56:04
+  expires_in: 2019-04-10 21:56:04
   scope: MyString
   id_token: MyString
   state: MyString
@@ -11,7 +11,7 @@ one:
 two:
   access_token: MyString
   token_type: MyString
-  expires_at: 2019-04-10 21:56:04
+  expires_in: 2019-04-10 21:56:04
   scope: MyString
   id_token: MyString
   state: MyString


### PR DESCRIPTION
Added support for the `aud` parameter in the OAuth authorization calls in the top sample apps:

- PKCE
- Node
- Rails: Vets Health, Vets Verification, Vets Claims

Also, fixed the applications that were not functioning properly.

[Regression Tests](https://github.com/department-of-veterans-affairs/vets-api-clients/files/5092145/API1981_Changes_And_Tests.docx)
