### PR TITLE
Fixing 0966 Submission redirection

### DIFF
--- a/samples/oauth_rails/VetsApiClaims/app/controllers/claims_controller.rb
+++ b/samples/oauth_rails/VetsApiClaims/app/controllers/claims_controller.rb
@@ -8,13 +8,13 @@ class ClaimsController < ApplicationController
   def index
     @claims = claims_service.claims
   rescue => e
-    redirect_back(fallback_location: root_path, alert: e.response.to_s )
+    redirect_back(fallback_location: root_path, alert: e&.response.to_s )
   end
 
   def show
     @claim = claims_service.claim(params[:id])
   rescue => e
-    redirect_back(fallback_location: root_path, alert: e.response.to_s )
+    redirect_back(fallback_location: root_path, alert: e&.response.to_s )
   end
 
   def active_itf
@@ -24,7 +24,7 @@ class ClaimsController < ApplicationController
              itf_service.user_active_itf
            end
   rescue => e
-    redirect_back(fallback_location: root_path, alert: e.response.to_s )
+    redirect_back(fallback_location: root_path, alert: e&.response.to_s )
   end
 
   def active_poa
@@ -34,32 +34,32 @@ class ClaimsController < ApplicationController
              poa_service.user_active_poa
            end
   rescue => e
-    redirect_back(fallback_location: root_path, alert: e.response.to_s )
+    redirect_back(fallback_location: root_path, alert: e&.response.to_s )
   end
 
   def form
     @schema = schema_service.schema(params[:form_number])[0]
   rescue => e
-    redirect_back(fallback_location: root_path, alert: e.response.to_s )
+    redirect_back(fallback_location: root_path, alert: e&.response.to_s )
   end
 
   def form_2122
-    super
   rescue => e
-    redirect_back(fallback_location: root_path, alert: e.response.to_s )
+    redirect_back(fallback_location: root_path, alert: e&.response.to_s )
   end
 
   def form_submit
     render json: schema_service.submit_form(params)
   rescue => e
-    redirect_back(fallback_location: root_path, alert: e.response.to_s )
+    redirect_back(fallback_location: root_path, alert: e&.response.to_s )
   end
 
   def form_show
     @form_number = params[:form_number]
+    params['id'] = 'active' if @form_number == '0966'
     @form = schema_service.show(params)
   rescue => e
-    redirect_back(fallback_location: root_path, alert: e.response.to_s )
+    redirect_back(fallback_location: root_path, alert: e&.response.to_s )
   end
 
   def poa_upload
@@ -73,7 +73,7 @@ class ClaimsController < ApplicationController
     JSON.parse(response&.body)['data']
     redirect_to claim_path(params[:id])
   rescue => e
-    redirect_back(fallback_location: root_path, alert: e.response.to_s )
+    redirect_back(fallback_location: root_path, alert: e&.response.to_s )
   end
 
   private

--- a/samples/oauth_rails/VetsApiClaims/app/services/schema_service.rb
+++ b/samples/oauth_rails/VetsApiClaims/app/services/schema_service.rb
@@ -25,6 +25,6 @@ class SchemaService < BaseClaimsService
   end
 
   def show(params)
-    get("#{BASE_PATH}/forms/#{params['form_number']}/#{params['id']}", authorization_header)
+    get("#{BASE_PATH}/forms/#{params['form_number']}/#{params['id']}?type=#{params['type']}", authorization_header)
   end
 end

--- a/samples/oauth_rails/VetsApiClaims/app/views/claims/form.html.erb
+++ b/samples/oauth_rails/VetsApiClaims/app/views/claims/form.html.erb
@@ -34,7 +34,7 @@
 
         $('#root_authenticity_token').attr('value', $('meta[name=csrf-token]').attr('content'))
         $.post(`${window.location.pathname}/submit`, formData, function(data) {
-          window.location.href = `${window.location.pathname}/${data.id}`
+          window.location.href = `${window.location.pathname}/${data.id}?type=${data.type}&${window.location.search.substr(1)}`
         })
 
       }


### PR DESCRIPTION
Not sure how we didn't catch this in our feature branch testing but the redirect should be redirecting to /active in the sample app since there is no show end point to look this up on.

{"errors":[\{"title":"Not found","detail":"There are no routes matching your request: services/claims/v1/forms/0966/184461","code":"411","status":"404"}
]}

For Ticket https://vajira.max.gov/browse/API-2162