### PR TITLE
API-5824: Issue keeping POA for Veteran's in sandbox the same as what is documented

### DIFF
--- a/test_accounts/benefits_test_accounts.md
+++ b/test_accounts/benefits_test_accounts.md
@@ -85,7 +85,7 @@ Test user 007 (John Doe) is a non-Veteran that can be added as a POA for any of 
 Also, any of the above Veterans can also be Representatives for another Veteran. In addition to accessing the VA data for those the Veteran represents, he/she can also access his/her own personal VA data. If the Representative attempts to read or write data for a Veteran test user they do not have POA for, the server will return a 401 Unauthorized error.
 
 Note: Power of attorney is live within the sandbox environment. Who a power of attorney is for each Veteran can, and will, change throughout the day.
-Please utilize the [POST /forms/2122](https://developer.va.gov/explore/benefits/docs/claims?version=current#operations-Power_of_Attorney-post2122) endpoint to update a Veteran's POA before attempting Representative interactions.
+Please utilize the [POST /forms/2122](https://developer.va.gov/explore/benefits/docs/claims?version=current#operations-Power_of_Attorney-post2122) endpoint (ideally as the Veteran directly) to update the Veteran's POA before attempting Representative interactions.
 
 Example of a Representative cURL command is provided below.
 

--- a/test_accounts/benefits_test_accounts.md
+++ b/test_accounts/benefits_test_accounts.md
@@ -101,3 +101,9 @@ curl -X GET \
   -H 'cache-control: no-cache'
 
 ```
+
+**Password for all ID.me accounts: Password1234!**
+
+|Email|First Name|Middle Name|Last Name|Sex| Birthdate |SSN|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|va.api.user+idme.007@gmail.com|John|| Doe |M|||

--- a/test_accounts/benefits_test_accounts.md
+++ b/test_accounts/benefits_test_accounts.md
@@ -80,9 +80,12 @@ These test users have Power of Attorney (POA) for specific Veterans and can be u
 
 **Both Veterans and non-Veterans can be Representatives.**
 
-Test user 007 (John Doe) is a non-Veteran with Power of Attorney for Veteran test users 001, 002, 003, 004, 005, and 006 (Tamara Ellis, Janet Moore, Ralph Lee, Jess Gray, Pauline Foster, and Russell Freeman). If test user 007 attempts to read or write data for a Veteran test user they do not have POA for, the server will return a 401 Unauthorized error.
+Test user 007 (John Doe) is a non-Veteran that can be added as a POA for any of the above Veterans (if not already). If test user 007 attempts to read or write data for a Veteran test user they do not have POA for, the server will return a 401 Unauthorized error.
 
-Test user 001 (Tamara Ellis) is both a Veteran and a Representative with Power of Attorney for Veteran test users 002, 003, 004, 005, and 006 (Janet Moore, Ralph Lee, Jess Gray, Pauline Foster, and Russell Freeman). In addition to accessing the VA data for the Veterans Tamara represents, she can also access her own personal VA data. If test user 001 attempts to read or write data for a Veteran test user they do not have POA for, the server will return a 401 Unauthorized error.
+Also, any of the above Veterans can also be Representatives for another Veteran. In addition to accessing the VA data for those the Veteran represents, he/she can also access his/her own personal VA data. If the Representative attempts to read or write data for a Veteran test user they do not have POA for, the server will return a 401 Unauthorized error.
+
+Note: Power of attorney is live within the sandbox environment. Who a power of attorney is for each Veteran can, and will, change throughout the day.
+Please utilize the [POST /forms/2122](https://developer.va.gov/explore/benefits/docs/claims?version=current#operations-Power_of_Attorney-post2122) endpoint to update a Veteran's POA before attempting Representative interactions.
 
 Example of a Representative cURL command is provided below.
 
@@ -98,5 +101,3 @@ curl -X GET \
   -H 'cache-control: no-cache'
 
 ```
-
-


### PR DESCRIPTION
Updates documentation a bit to recognize that POA for Veteran's is not set in stone in sandbox. POA can change/be changed in sandbox using the POA update endpoint within the Claims API.