### PR TITLE
API-6518: Document POA codes in sandbox

### DIFF
--- a/test_accounts/benefits_test_accounts.md
+++ b/test_accounts/benefits_test_accounts.md
@@ -84,11 +84,14 @@ Test user 007 (John Doe) is a non-Veteran that can be added as a POA for any of 
 
 Also, any of the above Veterans can also be Representatives for another Veteran. In addition to accessing the VA data for those the Veteran represents, he/she can also access his/her own personal VA data. If the Representative attempts to read or write data for a Veteran test user they do not have POA for, the server will return a 401 Unauthorized error.
 
-Note: Power of attorney is live within the sandbox environment. Who a power of attorney is for each Veteran can, and will, change throughout the day.
-Please utilize the [POST /forms/2122](https://developer.va.gov/explore/benefits/docs/claims?version=current#operations-Power_of_Attorney-post2122) endpoint (ideally as the Veteran directly) to update the Veteran's POA before attempting Representative interactions.
+**Note:** Power of attorney is live within the sandbox environment. Who a power of attorney is for each Veteran can, and will, change throughout the day.
+Please utilize the [POST /forms/2122](https://developer.va.gov/explore/benefits/docs/claims?version=current#operations-Power_of_Attorney-post2122) endpoint  to update the Veteran's POA before attempting Representative interactions.
+
+The following are the POA codes associated with both Tamara Ellis and John Doe in sandbox:
+`A1Q`, `095`, `074`, `083`, `1NY`. Any of these POA codes can be assigned to any Veteran in sandbox to then make calls as Tamara Ellis or John Doe on behalf of that Veteran.
+
 
 Example of a Representative cURL command is provided below.
-
 
 ```
 curl -X GET \


### PR DESCRIPTION
Added a bit of documentation around which poa codes are associated with our mock representatives in sandbox.

https://vajira.max.gov/browse/API-6518