### PR TITLE
API-6349 content changes for VV, Benefits, and Health APIs

### DIFF
--- a/test_accounts/benefits_test_accounts.md
+++ b/test_accounts/benefits_test_accounts.md
@@ -4,9 +4,13 @@ These test users have a variety of synthetic VA records and can be used to test 
 
 Power of Attorney (POA) test accounts are also available [here](https://github.com/department-of-veterans-affairs/vets-api-clients/blob/master/test_accounts/benefits_test_accounts.md#Representative).
 
-Use these test accounts to log into the ID.me sandbox environment that is connected to sandbox-api.va.gov. When signing in with a test account, Step 2 will ask how you want to receive an authentication code. Click "continue" for the verification to be automatically populated in Step 3.
+To log in to the sandbox environment with a test account, make sure you:
 
-**Do not modify any of the attributes for these test accounts, including passwords.** If you need to use one of these accounts for a different use case, [contact VA Lighthouse Support](https://github.com/department-of-veterans-affairs/vets-api-clients/issues/new/choose).
+  1. Choose an account that is specific to the API you want to test.
+  2. Use ID.me to sign in to the sandbox environment.
+  3. **Don’t change any preselected answers** when asked about receiving an authentication code. Just click “Continue” to go to the next step.
+
+**Do not modify any of the attributes for these test accounts, including passwords.** If you need to use one of these accounts for a different use case, [contact us](https://developer.va.gov/support/contact-us) on our developer portal.
 
 **Password for all ID.me accounts: Password1234!**
 

--- a/test_accounts/health_test_accounts.md
+++ b/test_accounts/health_test_accounts.md
@@ -2,9 +2,13 @@
 
 **Veteran Health** test users have a variety of synthetic health records attached to them and can be used to test the [Veteran Health API](https://developer.va.gov/explore/health/docs/fhir?version=current). A small subset of these users can also be used for testing the [Clinical Health API](https://developer.va.gov/explore/health/docs/clinical_health?version=current).
 
-Use these test accounts to log into the ID.me sandbox environment that is connected to sandbox-api.va.gov. When signing in with a test account, Step 2 will ask how you want to receive an authentication code. Click "continue" for the verification to be automatically populated in Step 3.
+To log in to the sandbox environment with a test account, make sure you:
 
-**Do not modify any of the attributes for these test accounts, including passwords.** If you need to use one of these accounts for a different use case, [contact VA Lighthouse Support](https://github.com/department-of-veterans-affairs/vets-api-clients/issues/new/choose).
+  1) Choose an account that is specific to the API you want to test.
+  2) Use ID.me to sign in to the sandbox environment.
+  3) **Don’t change any preselected answers** when asked about receiving an authentication code. Just click “Continue” to go to the next step.
+
+**Do not modify any of the attributes for these test accounts, including passwords.** If you need to use one of these accounts for a different use case, [contact us](https://developer.va.gov/support/contact-us) on our developer portal.
 
 **Password for all ID.me accounts: Password1234!**
 

--- a/test_accounts/verification_test_accounts.md
+++ b/test_accounts/verification_test_accounts.md
@@ -1,8 +1,14 @@
 # Sandbox Test Accounts for Veteran Verification APIs
 
-These test users have a variety of synthetic VA records such as service history and disability rating attached to them and can be used to test the [Veteran Verification API](https://developer.va.gov/explore/verification/docs/veteran_verification?version=current). 
+These test users have a variety of synthetic VA records such as service history and disability rating attached to them and can be used to test the [Veteran Verification API](https://developer.va.gov/explore/verification/docs/veteran_verification?version=current).
 
-**Do not modify any of the attributes for these test accounts, including passwords.** If you need to use one of these accounts for a different use case, [contact VA Lighthouse Support](https://github.com/department-of-veterans-affairs/vets-api-clients/issues/new/choose).
+To log in to the sandbox environment with a test account, make sure you:
+
+  1. Choose an account that is specific to the API you want to test.
+  2. Use ID.me to sign in to the sandbox environment.
+  3. **Don’t change any preselected answers** when asked about receiving an authentication code. Just click “Continue” to go to the next step.
+
+**Do not modify any of the attributes for these test accounts, including passwords**. If you need to use one of these accounts for a different use case, [contact us](https://developer.va.gov/support/contact-us) on our developer portal.
 
 **Password for all ID.me accounts: Password1234!**
 


### PR DESCRIPTION
Rewrite the content for verification_test_accounts.md, benefits_test_accounts.md, and health_test_accounts.md to have a step-by-step way of logging in to the sandbox environment. This makes clear to the user that a) they use ID.me to sign in and b) they don’t have to enter any new information for the 2-FA.