### PR TITLE
API-000 Update OAuth Node Dockerfile base to Node 16

### DIFF
--- a/samples/oauth_node/Dockerfile
+++ b/samples/oauth_node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:16
 
 # Create app directory
 WORKDIR /app

--- a/samples/oauth_node/package-lock.json
+++ b/samples/oauth_node/package-lock.json
@@ -15,7 +15,7 @@
         "ejs": "^3.0.2",
         "express": "^4.17.1",
         "express-session": "^1.17.1",
-        "openid-client": "^5.1.3",
+        "openid-client": "^5.1.5",
         "passport": "^0.4.1",
         "pug": "^3.0.2",
         "sqlite3": "^5.0.2"
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/openid-client": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.3.tgz",
-      "integrity": "sha512-i5quCXurPkN50ndRLE2D3Q6khz6AieJ0gTKOmsl3G4ZIP/Udf5Qw5CMRdhMvbFvfKRrkcCWPFXmduFUFYTC0xw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.5.tgz",
+      "integrity": "sha512-m41p7V/iXyqc0WZeo20uwKk8NPDAtYd3JS0uWjttcqwvFo4YNYAKegMAMea1qG5RClddQ6rV9ec/TP6ZvsCrYw==",
       "dependencies": {
         "jose": "^4.1.4",
         "lru-cache": "^6.0.0",
@@ -5065,9 +5065,9 @@
       }
     },
     "openid-client": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.3.tgz",
-      "integrity": "sha512-i5quCXurPkN50ndRLE2D3Q6khz6AieJ0gTKOmsl3G4ZIP/Udf5Qw5CMRdhMvbFvfKRrkcCWPFXmduFUFYTC0xw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.5.tgz",
+      "integrity": "sha512-m41p7V/iXyqc0WZeo20uwKk8NPDAtYd3JS0uWjttcqwvFo4YNYAKegMAMea1qG5RClddQ6rV9ec/TP6ZvsCrYw==",
       "requires": {
         "jose": "^4.1.4",
         "lru-cache": "^6.0.0",

--- a/samples/oauth_node/package.json
+++ b/samples/oauth_node/package.json
@@ -23,10 +23,10 @@
     "ejs": "^3.0.2",
     "express": "^4.17.1",
     "express-session": "^1.17.1",
-    "openid-client": "^5.1.3",
+    "openid-client": "^5.1.5",
     "passport": "^0.4.1",
     "pug": "^3.0.2",
-    "sqlite3": "^5.0.2"
+    "sqlite3": "^5.0.5"
   },
   "devDependencies": {
     "nodemon": "^2.0.4"


### PR DESCRIPTION
API-000 Update OAuth Node Dockerfile base to Node 16

- Upgrade Dockerfile Base image `FROM node:16`
- Updates `openid-client` to latest version
- Updates `sqlite3` to latest version

Addresses error with openid-client incompatibility with old Node 10 version.

```
$ cd vets-api-clients/samples/oauth_node/
$ docker run -p 8080:8080 oauth-node-sample-client
/app/node_modules/openid-client/lib/issuer.js:32
  #metadata;
  ^

SyntaxError: Invalid or unexpected token
    at Module._compile (internal/modules/cjs/loader.js:723:23)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (/app/node_modules/openid-client/lib/index.js:1:16)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
```