### PR TITLE
OAuth Samples Readme - Specify Node 16 working version

### DIFF
--- a/samples/oauth_node/README.md
+++ b/samples/oauth_node/README.md
@@ -34,7 +34,7 @@ Replace `FAKE_CLIENT_ID` and `FAKE_CLIENT_SECRET` with your ID and secret.
 
 ### Requirements
 
-* [Node 10.x.x or greater](https://nodejs.org/en/)
+* [Node 16.x.x is currently confirmed working version](https://nodejs.org/en/)
 * [NPM](https://www.npmjs.com/get-npm)
 
 ```

--- a/samples/oauth_pkce_cli/README.md
+++ b/samples/oauth_pkce_cli/README.md
@@ -24,6 +24,11 @@ It follows these steps:
 7. Displays the tokens returned from the `token` endpoint
 8. Uses the returned access token to call the `userinfo` endpoint
 
+### Requirements
+
+* [Node 16.x.x is currently confirmed working version](https://nodejs.org/en/)
+* [NPM](https://www.npmjs.com/get-npm)
+
 ## Initialize
 ```
 npm install


### PR DESCRIPTION
Update README.md for oauth_node & PKCE sample apps to call out Node 16 as current supported/tested version.

Future update may include additional supported versions after testing.