### PR TITLE
API-37596-point-to-public-file

### DIFF
--- a/test_accounts/health_test_accounts.md
+++ b/test_accounts/health_test_accounts.md
@@ -11,7 +11,7 @@ All Health test users below have a variety of synthetic health records attached 
 
 ## Veteran Account Information
 
-**NOTE:** Resource data about each test patient can be found in [Health Test Patient Data](https://github.com/department-of-veterans-affairs/health-apis-datamart-synthetic-records/blob/qa/health-test-patient-data.xlsx). 
+**NOTE:** Resource data about each test patient can be found in [Health Test Patient Data](https://github.com/department-of-veterans-affairs/lighthouse-fhir-apis-consumer-docs/blob/main/patient-health-v0/health-test-patient-data.xlsx). 
 
 | Id  | ICN      | First Name   | Last Name      | Sex | Birthdate |
 |-----|----------|--------------|----------------|-----|-----------|


### PR DESCRIPTION
The excel file referenced here became unavailable when the synthetic records repo was made internal as part of the LHDI migration process. The new [Lighthouse FHIR APIs Consumer Docs](https://github.com/department-of-veterans-affairs/lighthouse-fhir-apis-consumer-docs/tree/main) repo is intended to stay public and house any documentation we plan to make accessible to consumers through our public docs.