### PR TITLE
API-41583: Update Appeals API Test Account Pages for API Changes

### DIFF
--- a/test_accounts/appealable_issues_test_accounts.md
+++ b/test_accounts/appealable_issues_test_accounts.md
@@ -19,7 +19,7 @@ The authentication model for the [Appealable Issues API](https://developer.va.go
 
 These accounts can be used to test various data and response scenarios for the `GET /appealable-issues/{decisionReviewType}` endpoint. Note that in the sandbox environment, the same results will be returned regardless of the `decisionReviewType` supplied.
 
-An `icn` parameter is required when making a request. It should match the value in the ICN column below.
+An `icn` URL parameter is required when making requests using a representative- or system-scoped token. It is optional when making requests using a veteran-scoped token. If provided, the `icn` parameter value should match the value in the ICN column below.
 
 | Sandbox Response             | ICN               | First Name | Last Name |
 |:-----------------------------| :---------------- | :--------- | :-------- |
@@ -29,4 +29,4 @@ An `icn` parameter is required when making a request. It should match the value 
 | Appealable Issue (1)         | 1012667145V762142 | Tamara     | Ellis     |
 | Empty Response               | 1012666073V986297 | Jesse      | Gray      |
 | 404 Veteran Record Not Found | 1012845630V900607 | Pauline    | Foster    |
-| 500 Internal Server Error    | 1012666182V203559 | Greg       | Anderson  |
+| 502 Bad Gateway Error        | 1012666182V203559 | Greg       | Anderson  |

--- a/test_accounts/appeals_status_test_accounts.md
+++ b/test_accounts/appeals_status_test_accounts.md
@@ -19,7 +19,7 @@ The authentication model for the [Appeals Status API (v1)](https://developer.va.
 
 These accounts can be used to test various data and response scenarios for the `GET /appeals` endpoint. 
 
-An `icn` parameter and an `X-VA-User` header are required when making a request. The `icn` should match the value in the ICN column below, and the `X-VA-User` should match the test account's ID.me or Login.gov username (depending on the authentication method used) from the link provided when you signed up for sandbox access.
+An `icn` URL parameter is required when making requests using a representative- or system-scoped token. It is optional when making requests using a veteran-scoped token. If provided, the `icn` parameter value should match the value in the ICN column below.
 
 | Sandbox Response                                                    | ICN               | First Name | Last Name |
 |:--------------------------------------------------------------------|:------------------|:-----------|:----------|
@@ -29,4 +29,4 @@ An `icn` parameter and an `X-VA-User` header are required when making a request.
 | Legacy Appeal (1)                                                   | 1012667145V762142 | Tamara     | Ellis     |
 | Empty Response                                                      | 1012666073V986297 | Jesse      | Gray      |
 | 404 Veteran Record Not Found                                        | 1012845630V900607 | Pauline    | Foster    |
-| 500 Internal Server Error                                           | 1012666182V203559 | Greg       | Anderson  |
+| 502 Bad Gateway Error                                               | 1012666182V203559 | Greg       | Anderson  |

--- a/test_accounts/legacy_appeals_test_accounts.md
+++ b/test_accounts/legacy_appeals_test_accounts.md
@@ -19,7 +19,7 @@ The authentication model for the [Legacy Appeals API](https://developer.va.gov/e
 
 These accounts can be used to test various data and response scenarios for the `GET /legacy-appeals` endpoint. 
 
-An `icn` parameter is required when making a request. It should match the value in the ICN column below.
+An `icn` URL parameter is required when making requests using a representative- or system-scoped token. It is optional when making requests using a veteran-scoped token. If provided, the `icn` parameter value should match the value in the ICN column below.
 
 | Sandbox Response             | ICN               | First Name | Last Name |
 |:-----------------------------| :---------------- | :--------- | :-------- |
@@ -29,4 +29,4 @@ An `icn` parameter is required when making a request. It should match the value 
 | Legacy Appeal (1)            | 1012667145V762142 | Tamara     | Ellis     |
 | Empty Response               | 1012666073V986297 | Jesse      | Gray      |
 | 404 Veteran Record Not Found | 1012845630V900607 | Pauline    | Foster    |
-| 500 Internal Server Error    | 1012666182V203559 | Greg       | Anderson  |
+| 502 Bad Gateway Error        | 1012666182V203559 | Greg       | Anderson  |


### PR DESCRIPTION
## Summary
This PR updates the Appealable Issues API, Appeals Status v1 API, and Legacy Appeals API test account pages to account for changes made to the APIs since these pages were created, including:
1. The removal of the `X-VA-User` header from the Appeals Status v1 API.
2. A change to the `icn` URL parameter in all three APIs, where it's not required if the request is using a veteran-scoped token.
3. A change to the mocked response returned for the Greg Anderson test user, a 502 error rather than a 500 error.

## Requested Feedback
Looking for feedback on whether or not the modified instructions are clear for API consumers. Suggestions for improvement are welcome.