### PR TITLE
API-42883: Remove 502 Error Example for Appeals APIs

### DIFF
--- a/test_accounts/appealable_issues_test_accounts.md
+++ b/test_accounts/appealable_issues_test_accounts.md
@@ -29,4 +29,3 @@ An `icn` URL parameter is required when making requests using a representative- 
 | Appealable Issue (1)         | 1012667145V762142 | Tamara     | Ellis     |
 | Empty Response               | 1012666073V986297 | Jesse      | Gray      |
 | 404 Veteran Record Not Found | 1012845630V900607 | Pauline    | Foster    |
-| 502 Bad Gateway Error        | 1012666182V203559 | Greg       | Anderson  |

--- a/test_accounts/appeals_status_test_accounts.md
+++ b/test_accounts/appeals_status_test_accounts.md
@@ -29,4 +29,3 @@ An `icn` URL parameter is required when making requests using a representative- 
 | Legacy Appeal (1)                                                   | 1012667145V762142 | Tamara     | Ellis     |
 | Empty Response                                                      | 1012666073V986297 | Jesse      | Gray      |
 | 404 Veteran Record Not Found                                        | 1012845630V900607 | Pauline    | Foster    |
-| 502 Bad Gateway Error                                               | 1012666182V203559 | Greg       | Anderson  |

--- a/test_accounts/legacy_appeals_test_accounts.md
+++ b/test_accounts/legacy_appeals_test_accounts.md
@@ -29,4 +29,3 @@ An `icn` URL parameter is required when making requests using a representative- 
 | Legacy Appeal (1)            | 1012667145V762142 | Tamara     | Ellis     |
 | Empty Response               | 1012666073V986297 | Jesse      | Gray      |
 | 404 Veteran Record Not Found | 1012845630V900607 | Pauline    | Foster    |
-| 502 Bad Gateway Error        | 1012666182V203559 | Greg       | Anderson  |


### PR DESCRIPTION
## Summary

This PR updates the Appealable Issues API, Appeals Status v1 API, and Legacy Appeals API test account pages to remove the 502 error test account. It is being removed due to an error occurring in the Sandbox environment.